### PR TITLE
Update index.html

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -71,7 +71,8 @@
         docExpansion: "none",
         jsonEditor: false,
         defaultModelRendering: 'schema',
-        showRequestHeaders: false
+        showRequestHeaders: false,
+        validatorUrl: null
       });
 
       window.swaggerUi.load();


### PR DESCRIPTION
disable online validator, fixing the ugly red error box when hosted from non-localhost url's